### PR TITLE
FIX/ Validação código de patrimônio cadastro de itens

### DIFF
--- a/src/store/modules/itens/itens.js
+++ b/src/store/modules/itens/itens.js
@@ -65,7 +65,29 @@ export default {
         // Salva um objeto item novo ou editado no localStorage
         async saveItem(context, item) {
             context.commit("setExists", false);
-            await axios.post("http://localhost:5000/items/", item, {
+            await axios.get("http://localhost:5000/items/", {
+                headers: {
+                    'Authorization': cookies.get("logged").token,
+                }
+            })
+            .then(response => {
+                response.data.records.forEach(item => {
+                    context.commit("setItens", item);
+                });
+            });
+
+            context.state.itens.forEach(element => {
+                if (element.patrimonio === item.patrimonio) {
+                    context.commit("setExists", true);
+                }
+            });
+            
+            if (context.state.exists) {
+                context.commit('setMsgError', "Código de patrimônio já existente na base de dados!");
+                return false;
+            }
+
+            axios.post("http://localhost:5000/items/", item, {
                 headers: {
                     'Authorization': "Bearer" + cookies.get("logged").token,
                     'Access-Control-Allow-Origin': "http://localhost:5000/items/",
@@ -74,16 +96,6 @@ export default {
                     'Access-Control-Max-Age': '86400'
                 }
             })
-            .then((response) => {
-                console.log(response)
-                if (!response) {
-                    return true
-                }
-            })
-            .catch((e) => {
-                console.error("error", e)
-            })
-            
         },
 
         async saveItemedit(context, item) {
@@ -170,3 +182,6 @@ export default {
           },
     }
 }
+    
+
+    

--- a/src/store/modules/itens/itens.js
+++ b/src/store/modules/itens/itens.js
@@ -2,7 +2,6 @@ import axios from "axios";
 import { useCookies } from "vue3-cookies";
 const cookies = useCookies().cookies;
 
-
 export default {
     namespaced: true,
     state() {
@@ -76,18 +75,7 @@ export default {
                 });
             });
 
-            context.state.itens.forEach(element => {
-                if (element.patrimonio === item.patrimonio) {
-                    context.commit("setExists", true);
-                }
-            });
-            
-            if (context.state.exists) {
-                context.commit('setMsgError', "Código de patrimônio já existente na base de dados!");
-                return false;
-            }
-
-            axios.post("http://localhost:5000/items/", item, {
+            await axios.post("http://localhost:5000/items/", item, {
                 headers: {
                     'Authorization': "Bearer" + cookies.get("logged").token,
                     'Access-Control-Allow-Origin': "http://localhost:5000/items/",
@@ -95,6 +83,14 @@ export default {
                     'Access-Control-Allow-Headers': '*',
                     'Access-Control-Max-Age': '86400'
                 }
+            })
+            .then(() => {
+                return true;
+            })
+            .catch(e => {
+                context.commit("setExists", true);
+                context.commit('setMsgError', e.response.data.error);
+                return false;
             })
         },
 

--- a/src/views/CadastroItem.vue
+++ b/src/views/CadastroItem.vue
@@ -22,12 +22,14 @@
                     <div class="col-3">
                         <label class="form-label">Código de patrimônio</label>
                         <newitem-field 
-                        type="text" 
-                        class="form-control" 
-                        name="patrimonio" 
-                        v-model="item.patrimonio" 
-                        :disabled="disabled" 
-                        placeholder="XX9999-999"/>
+                            type="text" 
+                            class="form-control" 
+                            name="patrimonio" 
+                            v-model="item.patrimonio" 
+                            :disabled="disabled" 
+                            placeholder="XX9999-999"
+                            v-mask="'AA####-###'"
+                        />
                         <span 
                         class="text-danger" 
                         v-text="errors.patrimonio" 
@@ -163,13 +165,16 @@
 import { Form, Field } from 'vee-validate'
 import rules from '../validations/validateitens'
 import {mapMutations, mapState} from 'vuex'
+import { mask } from 'vue-the-mask'
 
 rules
 
 export default {
 
+    directives: {
+        mask
+    },
     components: {
-
         "newitem-form": Form,
         "newitem-field": Field,
     },

--- a/src/views/CadastroItem.vue
+++ b/src/views/CadastroItem.vue
@@ -6,7 +6,7 @@
             <div>
                 <span id="switch-editar">Editar</span>
                 <label class="switch">
-                    <input type="checkbox" @click="edit">
+                    <input type="checkbox" @click="this.disabled = !this.disabled">
                     <span class="slider round"></span>
                 </label>
              </div>
@@ -186,7 +186,7 @@ export default {
             },
             item: {}, // Recebe os inputs
             disabled: true, // Inputs desabilitados
-            // confirmError: 'Código de patrimônio já existe',
+            confirmError: 'Código de patrimônio já existe',
         }
     },
     methods: {
@@ -199,29 +199,20 @@ export default {
             this.item.emprestado = 'Item disponível'
             this.$store.dispatch('itens/saveItem', {...this.item})
             .then(() => {
-                console.log(this.exists)
-            if (this.exists) {
-                this.$toast.error(this.msgError, { position: "top" });
-            } else {
-                this.$toast.info("Usuário inserido com sucesso!", {
-                position: "top",
-                });
-                this.cleanForm();
-            }
+                if (this.exists) {
+                    this.$toast.error(this.msgError, { position: "top" });
+                } else {
+                    this.$toast.info("Item cadastrado com sucesso!", {
+                    position: "top",
+                    });
+                    this.cleanForm();
+                }
             });
         },
         cleanForm() {
             let form = document.getElementById('newitem-form')
             form.reset() 
         },
-        // habilita/desabilita edição dos campos
-        edit() {
-            if (this.disabled) {
-                this.disabled = false
-            } else {
-                this.disabled = true
-            }
-        }
     },
     computed:{
         itemsLocal(){


### PR DESCRIPTION
Adicionando tratamento no front-end para quando o back retorna 400 ao tentar cadastrar item por conta do código de patrimônio já for existente e exibindo o erro no toast para o usuário.